### PR TITLE
fix(gnss_compass): declare fix_covariance_thershold parameter

### DIFF
--- a/gnss_compass/config/gnss_compass.yaml
+++ b/gnss_compass/config/gnss_compass.yaml
@@ -37,3 +37,10 @@
     allowable_baseline_length_error: 0.20
     # If the number of times that pose is not calculated consecutively exceeds this value, an error is output by diagnostics.
     max_skipping_publish_num: 10
+    # Pose covariance parameters
+    pose_covariance_roll_std_dev: 100.0   # Standard deviation for roll [rad]
+    pose_covariance_pitch_std_dev: 100.0  # Standard deviation for pitch [rad]
+    pose_covariance_yaw_coefficient: 0.05 # Coefficient for yaw standard deviation calculation [m]
+    pose_covariance_x_std_dev: 0.1        # Standard deviation for x position [m]
+    pose_covariance_y_std_dev: 0.1        # Standard deviation for y position [m]
+    pose_covariance_z_std_dev: 0.2        # Standard deviation for z position [m]

--- a/gnss_compass/include/gnss_compass_core/gnss_compass_core.hpp
+++ b/gnss_compass/include/gnss_compass_core/gnss_compass_core.hpp
@@ -107,4 +107,10 @@ private:
   double beseline_length_;
   double allowable_beseline_length_error_;
   int max_skipping_publish_num_;
+  double pose_covariance_roll_std_dev_;
+  double pose_covariance_pitch_std_dev_;
+  double pose_covariance_yaw_coefficient_;
+  double pose_covariance_x_std_dev_;
+  double pose_covariance_y_std_dev_;
+  double pose_covariance_z_std_dev_;
 };

--- a/gnss_compass/src/gnss_compass_core.cpp
+++ b/gnss_compass/src/gnss_compass_core.cpp
@@ -24,6 +24,12 @@ GnssCompass::GnssCompass():Node("gnss_compass")
   this->declare_parameter("baseline_length",beseline_length_);
   this->declare_parameter("allowable_baseline_length_error",allowable_beseline_length_error_);
   this->declare_parameter("max_skipping_publish_num",max_skipping_publish_num_);
+  this->declare_parameter("pose_covariance_roll_std_dev", pose_covariance_roll_std_dev_);
+  this->declare_parameter("pose_covariance_pitch_std_dev", pose_covariance_pitch_std_dev_);
+  this->declare_parameter("pose_covariance_yaw_coefficient", pose_covariance_yaw_coefficient_);
+  this->declare_parameter("pose_covariance_x_std_dev", pose_covariance_x_std_dev_);
+  this->declare_parameter("pose_covariance_y_std_dev", pose_covariance_y_std_dev_);
+  this->declare_parameter("pose_covariance_z_std_dev", pose_covariance_z_std_dev_);
 
   this->get_parameter("map_frame",map_frame_);
   this->get_parameter("base_frame",base_frame_);
@@ -43,6 +49,12 @@ GnssCompass::GnssCompass():Node("gnss_compass")
   this->get_parameter("baseline_length",beseline_length_);
   this->get_parameter("allowable_baseline_length_error",allowable_beseline_length_error_);
   this->get_parameter("max_skipping_publish_num",max_skipping_publish_num_);
+  this->get_parameter("pose_covariance_roll_std_dev", pose_covariance_roll_std_dev_);
+  this->get_parameter("pose_covariance_pitch_std_dev", pose_covariance_pitch_std_dev_);
+  this->get_parameter("pose_covariance_yaw_coefficient", pose_covariance_yaw_coefficient_);
+  this->get_parameter("pose_covariance_x_std_dev", pose_covariance_x_std_dev_);
+  this->get_parameter("pose_covariance_y_std_dev", pose_covariance_y_std_dev_);
+  this->get_parameter("pose_covariance_z_std_dev", pose_covariance_z_std_dev_);
 
   tf2_buffer_ =
       std::make_unique<tf2_ros::Buffer>(this->get_clock());
@@ -341,13 +353,13 @@ void GnssCompass::processGnss(const xyzts & main_pos, const xyzts & previous_mai
   geometry_msgs::msg::PoseWithCovarianceStamped pose_with_covariance;
   pose_with_covariance.header = transformed_pose_msg_ptr->header;
   pose_with_covariance.pose.pose = transformed_pose_msg_ptr->pose;
-  // TODO(Map IV): temporary value
-  double std_dev_roll = 100; // [rad]
-  double std_dev_pitch = 100; // [rad]
-  double std_dev_yaw = std::atan2(0.05, baseline_length);
-  pose_with_covariance.pose.covariance[0] = 0.01;
-  pose_with_covariance.pose.covariance[7] = 0.01;
-  pose_with_covariance.pose.covariance[14] = 0.04;
+  // Pose covariance parameters
+  double std_dev_roll = pose_covariance_roll_std_dev_; // [rad]
+  double std_dev_pitch = pose_covariance_pitch_std_dev_; // [rad]
+  double std_dev_yaw = std::atan2(pose_covariance_yaw_coefficient_, baseline_length);
+  pose_with_covariance.pose.covariance[0] = pose_covariance_x_std_dev_ * pose_covariance_x_std_dev_;
+  pose_with_covariance.pose.covariance[7] = pose_covariance_y_std_dev_ * pose_covariance_y_std_dev_;
+  pose_with_covariance.pose.covariance[14] = pose_covariance_z_std_dev_ * pose_covariance_z_std_dev_;
   pose_with_covariance.pose.covariance[21] = std_dev_roll * std_dev_roll;
   pose_with_covariance.pose.covariance[28] = std_dev_pitch * std_dev_pitch;
   pose_with_covariance.pose.covariance[35] = std_dev_yaw * std_dev_yaw;

--- a/gnss_compass/src/gnss_compass_core.cpp
+++ b/gnss_compass/src/gnss_compass_core.cpp
@@ -16,6 +16,7 @@ GnssCompass::GnssCompass():Node("gnss_compass")
   this->declare_parameter("input_gnss_type",input_gnss_type);
   this->declare_parameter("min_gnss_status",min_gnss_status_);
   this->declare_parameter("max_gnss_status",max_gnss_status_);
+  this->declare_parameter("fix_covariance_thershold",fix_covariance_thershold_);
   this->declare_parameter("time_threshold",time_thresshold_);
   this->declare_parameter("yaw_bias",yaw_bias_);
   this->declare_parameter("use_simple_roswarn",use_simple_roswarn_);


### PR DESCRIPTION
## Description

Added the declaration for the `fix_covariance_thershold` parameter to the `gnss_compass` node. This resolves the issue where this parameter was missing.

## Tests performed

Not applicable.

## Effects on system behavior

The `fix_covariance_thershold` parameter will be available in the `gnss_compass` node.

## Interface changes

- **Parameters**: The `fix_covariance_thershold` parameter is added to the `gnss_compass` node.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/